### PR TITLE
Speed improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# Blurhash decoder
+# Blurhash
+
+Display blur hashes in elm. Blurhash is ["A very compact representation of a placeholder for an image"](https://blurha.sh/).
+The hash is sent as a small string (for example in a json payload) and can be loaded more quickly than a large image file.
+
+![the blurhash process](https://github.com/woltapp/blurhash/raw/master/Media/HowItWorks1.jpg)
+
+
+This package turns the blurhash string into an image, which can be loaded into a document as a base64-encoded uri.
+
+```elm
+import Blurhash
+import Html exposing (Html)
+import Html.Attributes
+
+main : Html msg
+main =
+    let
+        uri =
+            Blurhash.toUri { width = 30, height = 30 }
+                1.0
+                "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+    in
+    Html.img
+        [ Html.Attributes.style "width" "400px"
+        , Html.Attributes.src uri
+        ]
+        []
+```
+
+Just for fun there is also an encoder. May not be the most useful thing right now but who knows.

--- a/elm.json
+++ b/elm.json
@@ -13,7 +13,8 @@
         "danfishgold/base64-bytes": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
         "elm-community/list-extra": "8.2.2 <= v < 9.0.0",
-        "justgook/elm-image": "2.0.1 <= v < 3.0.0"
+        "justgook/elm-image": "2.0.1 <= v < 3.0.0",
+        "jxxcarlson/elm-cell-grid": "8.0.0 <= v < 9.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"

--- a/elm.json
+++ b/elm.json
@@ -9,8 +9,13 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "avh4/elm-color": "1.0.0 <= v < 2.0.0",
+        "danfishgold/base64-bytes": "1.0.2 <= v < 2.0.0",
         "elm/core": "1.0.2 <= v < 2.0.0",
-        "elm-community/list-extra": "8.2.2 <= v < 9.0.0"
+        "elm-community/list-extra": "8.2.2 <= v < 9.0.0",
+        "justgook/elm-image": "2.0.1 <= v < 3.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "1.2.2 <= v < 2.0.0"
+    }
 }

--- a/example/elm.json
+++ b/example/elm.json
@@ -9,23 +9,16 @@
         "direct": {
             "avh4/elm-color": "1.0.0",
             "danfishgold/base64-bytes": "1.0.2",
-            "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
-            "elm/svg": "1.0.1",
             "justgook/elm-image": "2.0.1"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/file": "1.0.5",
             "elm/json": "1.1.3",
-            "elm/random": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "elm-community/typed-svg": "5.1.0",
-            "folkertdev/elm-flate": "2.0.3",
-            "mpizenberg/elm-pointer-events": "4.0.1"
+            "elm-community/list-extra": "8.2.2",
+            "folkertdev/elm-flate": "2.0.3"
         }
     },
     "test-dependencies": {

--- a/example/elm.json
+++ b/example/elm.json
@@ -7,23 +7,25 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
+            "avh4/elm-color": "1.0.0",
+            "danfishgold/base64-bytes": "1.0.2",
             "elm/browser": "1.0.1",
             "elm/core": "1.0.2",
             "elm/html": "1.0.0",
             "elm/svg": "1.0.1",
-            "elm-community/list-extra": "8.2.2",
-            "elm-explorations/linear-algebra": "1.0.3",
-            "elm-explorations/webgl": "1.1.1",
-            "danfishgold/base64-bytes": "1.0.2",
-            "justgook/elm-image": "1.0.0"
+            "justgook/elm-image": "2.0.1"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
+            "elm/file": "1.0.5",
             "elm/json": "1.1.3",
+            "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.2",
-            "folkertdev/elm-flate": "1.0.1"
+            "elm-community/typed-svg": "5.1.0",
+            "folkertdev/elm-flate": "2.0.3",
+            "mpizenberg/elm-pointer-events": "4.0.1"
         }
     },
     "test-dependencies": {

--- a/example/src/Main.elm
+++ b/example/src/Main.elm
@@ -1,41 +1,20 @@
 module Main exposing (main)
 
-import Base64
-import Bitwise
 import Blurhash
-import Browser exposing (Document)
-import Html as H exposing (Html)
-import Html.Attributes as HA
-import Image exposing (Image)
+import Html exposing (Html)
+import Html.Attributes
 
 
-main : Platform.Program () () Never
+main : Html msg
 main =
-    Browser.sandbox
-        { init = ()
-        , update = \_ _ -> ()
-        , view = \_ -> view
-        }
-
-
-
--- VIEW
-
-
-view : Html Never
-view =
     let
-        pngEncodeBase64 =
-            Blurhash.decode 30 30 1.0 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
-                |> List.map rgbToInt
-                |> Image.fromList 30
-                |> Image.encodePng
-                |> Base64.fromBytes
-                |> Maybe.withDefault ""
+        uri =
+            Blurhash.toUri { width = 30, height = 30 }
+                1.0
+                "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
     in
-    H.img [ HA.style "width" "400px", HA.src ("data:image/png;base64," ++ pngEncodeBase64) ] []
-
-
-rgbToInt : ( Int, Int, Int ) -> Int
-rgbToInt ( r, g, b ) =
-    Bitwise.shiftLeftBy 24 r + Bitwise.shiftLeftBy 16 g + Bitwise.shiftLeftBy 8 b + 255
+    Html.img
+        [ Html.Attributes.style "width" "400px"
+        , Html.Attributes.src uri
+        ]
+        []

--- a/src/Blurhash.elm
+++ b/src/Blurhash.elm
@@ -22,56 +22,58 @@ base83chars =
 -}
 decodeBase83 : String -> Int
 decodeBase83 =
-    List.foldl
-        (\a acc ->
+    let
+        folder a acc =
             Dict.get a base83chars
                 |> Maybe.map ((+) (acc * 83))
                 |> Maybe.withDefault acc
-        )
-        0
-        << String.toList
+    in
+    String.foldl folder 0
 
 
 {-| srgb 0-255 integer to linear 0.0-1.0 floating point conversion.
 -}
 srgbToLinear : Int -> Float
 srgbToLinear srgbInt =
-    (toFloat srgbInt / 255)
-        |> (\a ->
-                if a <= 0.04045 then
-                    a / 12.92
+    let
+        a =
+            toFloat srgbInt / 255
+    in
+    if a <= 0.04045 then
+        a / 12.92
 
-                else
-                    ((a + 0.055) / 1.055) ^ 2.4
-           )
+    else
+        ((a + 0.055) / 1.055) ^ 2.4
 
 
 {-| linear 0.0-1.0 floating point to srgb 0-255 integer conversion.
 -}
 linearToSrgb : Float -> Int
 linearToSrgb linearFloat =
-    clamp 0 1 linearFloat
-        |> (\a ->
-                if a <= 0.0031308 then
-                    floor (a * 12.92 * 255 + 0.5)
+    let
+        a =
+            clamp 0 1 linearFloat
+    in
+    if a <= 0.0031308 then
+        floor (a * 12.92 * 255 + 0.5)
 
-                else
-                    floor ((1.055 * (a ^ (1 / 2.4)) - 0.055) * 255 + 0.5)
-           )
+    else
+        floor ((1.055 * (a ^ (1 / 2.4)) - 0.055) * 255 + 0.5)
 
 
 {-| Sign-preserving exponentiation.
 -}
 signPow : number -> number -> number
 signPow value exp =
-    (value ^ exp)
-        |> (\a ->
-                if value < 0 then
-                    a * -1
+    let
+        a =
+            value ^ exp
+    in
+    if value < 0 then
+        a * -1
 
-                else
-                    a
-           )
+    else
+        a
 
 
 type alias Metadata =
@@ -98,16 +100,17 @@ decodeMetadata punch s =
 
 decodeAC : Float -> Int -> ( Float, Float, Float )
 decodeAC maximumValue value =
-    ( toFloat value / (19 * 19)
-    , toFloat value / 19 |> floor |> modBy 19 |> toFloat
-    , value |> modBy 19 |> toFloat
+    let
+        ( a1, a2, a3 ) =
+            ( toFloat value / (19 * 19)
+            , toFloat value / 19 |> floor |> modBy 19 |> toFloat
+            , value |> modBy 19 |> toFloat
+            )
+    in
+    ( signPow ((a1 - 9) / 9) 2 * maximumValue
+    , signPow ((a2 - 9) / 9) 2 * maximumValue
+    , signPow ((a3 - 9) / 9) 2 * maximumValue
     )
-        |> (\( a1, a2, a3 ) ->
-                ( signPow ((a1 - 9) / 9) 2 * maximumValue
-                , signPow ((a2 - 9) / 9) 2 * maximumValue
-                , signPow ((a3 - 9) / 9) 2 * maximumValue
-                )
-           )
 
 
 {-| Decodes given blurhash to an RGB image with specified dimensions

--- a/src/Blurhash.elm
+++ b/src/Blurhash.elm
@@ -1,6 +1,7 @@
 module Blurhash exposing (decode)
 
 import Bitwise
+import CellGrid exposing (Dimensions)
 import Dict exposing (Dict)
 import List.Extra
 
@@ -125,20 +126,22 @@ decode width height punch blurhash =
         metadata =
             decodeMetadata punch blurhash
     in
-    List.range 0 (height * width - 1)
-        |> List.map
-            ((\( x, y ) ->
-                calcPixel
-                    { x = x
-                    , y = y
-                    , width = width
-                    , height = height
-                    , blurhash = blurhash
-                    , metadata = metadata
-                    }
-             )
-                << (\a -> ( a |> modBy width, floor (toFloat a / toFloat width) ))
-            )
+    CellGrid.initialize (Dimensions height width)
+        (initializer { width = width, height = height, metadata = metadata, blurhash = blurhash })
+        |> CellGrid.foldr (::) []
+
+
+initializer : { width : Int, height : Int, blurhash : String, metadata : Metadata } -> Int -> Int -> ( Int, Int, Int )
+initializer { width, height, blurhash, metadata } y x =
+    -- Note swapping of the axes: the `y` argument is the row, `x` the column
+    calcPixel
+        { x = x
+        , y = y
+        , width = width
+        , height = height
+        , blurhash = blurhash
+        , metadata = metadata
+        }
 
 
 calcPixel :

--- a/src/Blurhash.elm
+++ b/src/Blurhash.elm
@@ -1,50 +1,35 @@
-module Blurhash exposing (toUri)
+module Blurhash exposing
+    ( toUri
+    , fromImage, fromPixels
+    , encodeBase83, decodeBase83
+    )
 
 {-| Display blur hashes in elm
 
-    import Blurhash
-    import Html exposing (Html)
-    import Html.Attributes
-
-    main : Html msg
-    main =
-        let
-            uri =
-                Blurhash.toUri { width = 30, height = 30 }
-                    1.0
-                    "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
-        in
-        Html.img
-            [ Html.Attributes.style "width" "400px"
-            , Html.Attributes.src uri
-            ]
-            []
-
 @docs toUri
+
+
+## Encoding
+
+Create a blurhash from an image. Unlikely this is useful, but here it is.
+
+@docs fromImage, fromPixels
+
+
+## Base83
+
+@docs encodeBase83, decodeBase83
 
 -}
 
-import Base64
-import Bitwise
+import Array
+import CellGrid exposing (CellGrid)
 import Color exposing (Color)
-import Dict exposing (Dict)
 import Image
-import Image.Color
+import Internal
 
 
-type alias Dimensions =
-    { rows : Int
-    , columns : Int
-    }
-
-
-type Triplet a
-    = Triplet a a a
-
-
-{-| Convert a blurhash into an image URI.
-
-The float parameter is the `punch`, used to increase/decrease contrast of the resulting image
+{-| Convert a blurhash into an image URI. The float parameter is the `punch`, used to increase/decrease contrast of the resulting image
 
     punch : Float
     punch =
@@ -55,292 +40,70 @@ The float parameter is the `punch`, used to increase/decrease contrast of the re
         "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
 
     Blurhash.toUri { width = 4, height = 4 } punch hash
-    --> "data:image/bmp;base64,Qk2KAAAAAAAAAHoAAABsAAAAAgAAAAIAAAABACAAAwAAABAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/XY3A/z9+w/9djcD/P37D"
+    -->  "data:image/bmp;base64,Qk26AAAAAAAAAHoAAABsAAAABAAAAAQAAAABACAAAwAAAEAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/WovA/0F+wv87fs3/UIXI/12Lxf85eMH/Q4DT/1iK0f9djrr/TYGy/0Z/uf9RhMD/UYWu/1OHr/9Bfqn/T4Gv"
+
+"
 
 -}
 toUri : { width : Int, height : Int } -> Float -> String -> String
-toUri { width, height } punch blurhash =
-    foldGrid width height punch blurhash folderList2d { row = [], rows = [] }
-        |> .rows
-        |> Image.Color.fromList2d
-        |> Image.encodeBmp
-        |> Base64.fromBytes
-        |> Maybe.withDefault ""
-        |> (\uri -> "data:image/bmp;base64," ++ uri)
+toUri =
+    Internal.toUri
 
 
+{-| Decode a base83 string
 
--- Phase 1: decode metadata
+    decodeBase83 "X"
+        --> 33
 
+    decodeBase83 "foo"
+        --> 286649
 
-{-| Create a list from the image represented by a blurhash
-
-This type is generic so we can generate both a flat list and a 2D list by picking a different folder and default.
-
--}
-foldGrid : Int -> Int -> Float -> String -> ((Int -> Int -> Color) -> Int -> Int -> b -> b) -> b -> b
-foldGrid width height punch blurhash folder default =
-    let
-        sizeInfo : Int
-        sizeInfo =
-            decodeBase83 (String.slice 0 1 blurhash)
-
-        maximumValue : Float
-        maximumValue =
-            let
-                a =
-                    decodeBase83 (String.slice 1 2 blurhash)
-            in
-            (toFloat (a + 1) / 166) * punch
-
-        dimensions : Dimensions
-        dimensions =
-            Dimensions height width
-
-        filter : Dimensions
-        filter =
-            Dimensions ((sizeInfo // 9) + 1) ((sizeInfo |> modBy 9) + 1)
-
-        lookup : Int -> Triplet Float
-        lookup =
-            buildDict { rows = height, columns = width } maximumValue blurhash
-
-        toValue : Int -> Int -> Color
-        toValue row column =
-            calcPixel column row width height filter lookup
-    in
-    foldDimensionsReversed dimensions (folder toValue) default
-
-
-
--- Phase 2: decoding the blur hash into a function `Int -> Triplet Float`
-
-
-base83chars : Dict Char Int
-base83chars =
-    let
-        folder char { index, dict } =
-            { index = index + 1
-            , dict = Dict.insert char index dict
-            }
-    in
-    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~"
-        |> String.foldl folder { index = 0, dict = Dict.empty }
-        |> .dict
-
-
-{-| Decode a base83 string, as used in blurhash, to an integer.
 -}
 decodeBase83 : String -> Int
-decodeBase83 str =
-    let
-        folder a acc =
-            case Dict.get a base83chars of
-                Just v ->
-                    v + acc * 83
-
-                Nothing ->
-                    acc
-    in
-    String.foldl folder 0 str
+decodeBase83 =
+    Internal.decodeBase83
 
 
-{-| Sign-preserving exponentiation.
+{-| encode an integer in base 83, the second parameter is the width: the number will be padded with 0's on the left untill that length is reached.
+
+    encodeBase83 { padTo = 2 } 4
+        --> "04"
+
+    encodeBase83 { padTo = 4 } 4
+        --> "0004"
+
+    encodeBase83 { padTo = 4 } 420
+        --> "0055"
+
 -}
-signPow : number -> number -> number
-signPow value exp =
-    if value < 0 then
-        -(value ^ exp)
-
-    else
-        value ^ exp
+encodeBase83 : { padTo : Int } -> Int -> String
+encodeBase83 { padTo } value =
+    Internal.encodeBase83 value padTo
 
 
-decodeAC : Float -> Int -> Triplet Float
-decodeAC maximumValue value =
-    let
-        a1 =
-            toFloat value / (19 * 19)
-
-        a2 =
-            value // 19 |> modBy 19 |> toFloat
-
-        a3 =
-            value |> modBy 19 |> toFloat
-    in
-    Triplet
-        (signPow ((a1 - 9) / 9) 2 * maximumValue)
-        (signPow ((a2 - 9) / 9) 2 * maximumValue)
-        (signPow ((a3 - 9) / 9) 2 * maximumValue)
-
-
-buildDict : Dimensions -> Float -> String -> (Int -> Triplet Float)
-buildDict dimensions maximumValue blurhash =
-    let
-        cache : Dict Int (Triplet Float)
-        cache =
-            foldDimensions dimensions
-                (\row column dict ->
-                    case row * dimensions.columns + column of
-                        0 ->
-                            let
-                                bits =
-                                    decodeBase83 (String.slice 2 6 blurhash)
-
-                                value =
-                                    Triplet
-                                        (srgbToLinear (bits |> Bitwise.shiftRightBy 16))
-                                        (srgbToLinear (bits |> Bitwise.shiftRightBy 8 |> Bitwise.and 255))
-                                        (srgbToLinear (bits |> Bitwise.and 255))
-                            in
-                            Dict.insert 0 value dict
-
-                        i ->
-                            let
-                                key =
-                                    String.slice (4 + i * 2) (4 + (i + 1) * 2) blurhash
-                            in
-                            Dict.insert i (decodeAC maximumValue (decodeBase83 key)) dict
-                )
-                Dict.empty
-    in
-    -- creating a new function with one argument here make sure that the
-    -- cache is only created once, then re-used for all subsequent calls.
-    -- this works because we partially apply all arguments needed above.
-    \index ->
-        case Dict.get index cache of
-            Just v ->
-                v
-
-            Nothing ->
-                Triplet 0 0 0
-
-
-
--- Phase 3: determine the color at a position
-
-
-calcPixel : Int -> Int -> Int -> Int -> Dimensions -> (Int -> Triplet Float) -> Color
-calcPixel x y width height filter lookup =
-    let
-        folder row column (Triplet pixel0 pixel1 pixel2) =
-            let
-                basis : Float
-                basis =
-                    cos (pi * toFloat x * toFloat column / toFloat width)
-                        * cos (pi * toFloat y * toFloat row / toFloat height)
-
-                (Triplet colour0 colour1 colour2) =
-                    lookup (row * filter.columns + column)
-            in
-            Triplet
-                (pixel0 + colour0 * basis)
-                (pixel1 + colour1 * basis)
-                (pixel2 + colour2 * basis)
-
-        (Triplet r g b) =
-            foldDimensions filter folder (Triplet 0 0 0)
-    in
-    Color.rgb255 (linearToSrgb r) (linearToSrgb g) (linearToSrgb b)
-
-
-
--- Color conversion
-
-
-{-| srgb 0-255 integer to linear 0.0-1.0 floating point conversion.
+{-| Encode an image as a blur hash. The `Image` type is from [`justgook/elm-image`](https://package.elm-lang.org/packages/justgook/elm-image/latest/)
 -}
-srgbToLinear : Int -> Float
-srgbToLinear srgbInt =
-    let
-        a =
-            toFloat srgbInt / 255
-    in
-    if a <= 0.04045 then
-        a / 12.92
-
-    else
-        ((a + 0.055) / 1.055) ^ 2.4
+fromImage : { width : Int, height : Int } -> Image.Image -> String
+fromImage =
+    Internal.encode
 
 
-{-| linear 0.0-1.0 floating point to srgb 0-255 integer conversion.
+{-| Encode an array of pixel colors as a blur hash
+
+    import Color exposing (Color)
+    import Array exposing (Array)
+
+    pixels : Array Color
+    pixels =
+        Array.initialize 25 (\i -> Color.rgb255 i i i)
+
+    mask : { width : Int, height : Int }
+    mask = { width = 4, height = 4}
+
+    fromPixels mask { rows = 5, columns = 5 } pixels
+        --> "U01fC^t7WB%MIUWBayWBIUWBfQWB%Mj[ayof"
+
 -}
-linearToSrgb : Float -> Int
-linearToSrgb linearFloat =
-    let
-        a =
-            clamp 0 1 linearFloat
-    in
-    if a <= 0.0031308 then
-        floor (a * 12.92 * 255 + 0.5)
-
-    else
-        floor ((1.055 * (a ^ (1 / 2.4)) - 0.055) * 255 + 0.5)
-
-
-
--- Efficient folding over all positions in a grid
-
-
-decode : Int -> Int -> Float -> String -> List Color
-decode width height punch blurhash =
-    foldGrid width height punch blurhash folderList1d []
-
-
-{-| Fold from the top-left to the bottom-right. Useful for building up arrays
--}
-foldDimensions : Dimensions -> (Int -> Int -> a -> a) -> a -> a
-foldDimensions { rows, columns } folder default =
-    let
-        go row column accum =
-            if column < columns - 1 then
-                go row (column + 1) (folder row column accum)
-
-            else if row < rows - 1 then
-                go (row + 1) 0 (folder row column accum)
-
-            else
-                folder row column accum
-    in
-    go 0 0 default
-
-
-{-| Fold from the bottom-right to the top-left Useful for building up lists
--}
-foldDimensionsReversed : Dimensions -> (Int -> Int -> a -> a) -> a -> a
-foldDimensionsReversed { rows, columns } folder default =
-    let
-        go row column accum =
-            if column > 0 then
-                go row (column - 1) (folder row column accum)
-
-            else if row > 0 then
-                go (row - 1) (columns - 1) (folder row column accum)
-
-            else
-                folder row column accum
-    in
-    go (rows - 1) (columns - 1) default
-
-
-{-| Build up a flat list
--}
-folderList1d : (Int -> Int -> a) -> Int -> Int -> List a -> List a
-folderList1d toValue row column accum =
-    toValue row column :: accum
-
-
-{-| Build up a 2D list
--}
-folderList2d : (Int -> Int -> a) -> Int -> Int -> { row : List a, rows : List (List a) } -> { row : List a, rows : List (List a) }
-folderList2d toValue row column r =
-    let
-        value =
-            toValue row column
-    in
-    case column of
-        0 ->
-            { row = [], rows = (value :: r.row) :: r.rows }
-
-        _ ->
-            { row = value :: r.row, rows = r.rows }
+fromPixels : { width : Int, height : Int } -> { rows : Int, columns : Int } -> Array.Array Color -> String
+fromPixels mask dimensions pixels =
+    Internal.encodeCellGrid mask (CellGrid.CellGrid dimensions pixels)

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -1,0 +1,568 @@
+module Blurhash exposing
+    ( toUri
+    , toCellGrid
+    , encode, encodeBase83
+    )
+
+{-| Display blur hashes in elm
+
+    import Blurhash
+    import Html exposing (Html)
+    import Html.Attributes
+
+    main : Html msg
+    main =
+        let
+            uri =
+                Blurhash.toUri { width = 30, height = 30 }
+                    1.0
+                    "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+        in
+        Html.img
+            [ Html.Attributes.style "width" "400px"
+            , Html.Attributes.src uri
+            ]
+            []
+
+@docs toUri
+@docs toCellGrid
+@docs encode, encodeBase83
+
+-}
+
+import Array
+import Base64
+import Bitwise
+import CellGrid exposing (CellGrid, Position)
+import Color exposing (Color)
+import Dict exposing (Dict)
+import Image
+import Image.Color
+
+
+type alias Dimensions =
+    { rows : Int
+    , columns : Int
+    }
+
+
+type Triplet a
+    = Triplet a a a
+
+
+{-| Convert a blurhash into an image URI.
+
+The float parameter is the `punch`, used to increase/decrease contrast of the resulting image
+
+    punch : Float
+    punch =
+        0.9
+
+    hash : String
+    hash =
+        "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+
+    Blurhash.toUri { width = 4, height = 4 } punch hash
+    --> "data:image/bmp;base64,Qk2KAAAAAAAAAHoAAABsAAAAAgAAAAIAAAABACAAAwAAABAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/XY3A/z9+w/9djcD/P37D"
+
+-}
+toUri : { width : Int, height : Int } -> Float -> String -> String
+toUri { width, height } punch blurhash =
+    foldGrid width height punch blurhash folderList2d { row = [], rows = [] }
+        |> .rows
+        |> Image.Color.fromList2d
+        |> Image.encodeBmp
+        |> Base64.fromBytes
+        |> Maybe.withDefault ""
+        |> (\uri -> "data:image/bmp;base64," ++ uri)
+
+
+{-| Helper for testing
+-}
+toCellGrid : { width : Int, height : Int } -> Float -> String -> CellGrid Color
+toCellGrid { width, height } punch blurhash =
+    CellGrid.CellGrid (Dimensions height width) (Array.fromList (foldGrid width height punch blurhash folderList1d []))
+
+
+
+-- Phase 1: decode metadata
+
+
+{-| Create a list from the image represented by a blurhash
+
+This type is generic so we can generate both a flat list and a 2D list by picking a different folder and default.
+
+-}
+foldGrid : Int -> Int -> Float -> String -> ((Int -> Int -> Color) -> Int -> Int -> b -> b) -> b -> b
+foldGrid width height punch blurhash folder default =
+    let
+        sizeInfo : Int
+        sizeInfo =
+            decodeBase83 (String.slice 0 1 blurhash)
+
+        maximumValue : Float
+        maximumValue =
+            let
+                a =
+                    decodeBase83 (String.slice 1 2 blurhash)
+            in
+            (toFloat (a + 1) / 166) * punch
+
+        dimensions : Dimensions
+        dimensions =
+            Dimensions height width
+
+        filter : Dimensions
+        filter =
+            { rows = (sizeInfo // 9) + 1
+            , columns = (sizeInfo |> modBy 9) + 1
+            }
+
+        lookup : Int -> Triplet Float
+        lookup =
+            buildDict filter maximumValue blurhash
+
+        toValue : Int -> Int -> Color
+        toValue row column =
+            calcPixel column row width height filter lookup
+    in
+    foldDimensionsReversed dimensions (folder toValue) default
+
+
+
+-- Phase 2: decoding the blur hash into a function `Int -> Triplet Float`
+
+
+alphabet : String
+alphabet =
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~"
+
+
+base83chars : Dict Char Int
+base83chars =
+    let
+        folder char { index, dict } =
+            { index = index + 1
+            , dict = Dict.insert char index dict
+            }
+    in
+    alphabet
+        |> String.foldl folder { index = 0, dict = Dict.empty }
+        |> .dict
+
+
+{-| Decode a base83 string, as used in blurhash, to an integer.
+-}
+decodeBase83 : String -> Int
+decodeBase83 str =
+    let
+        folder a acc =
+            case Dict.get a base83chars of
+                Just v ->
+                    v + acc * 83
+
+                Nothing ->
+                    acc
+    in
+    String.foldl folder 0 str
+
+
+{-| Sign-preserving exponentiation.
+-}
+signPow : number -> number -> number
+signPow value exp =
+    if value < 0 then
+        -(abs value ^ exp)
+
+    else
+        value ^ exp
+
+
+decodeAC : Float -> Int -> Triplet Float
+decodeAC maximumValue value =
+    Triplet
+        (signPow ((toFloat (floor (toFloat value / (19 * 19))) - 9.0) / 9.0) 2.0 * maximumValue)
+        (signPow ((toFloat (floor (toFloat value / 19) |> modBy 19) - 9.0) / 9.0) 2.0 * maximumValue)
+        (signPow ((toFloat (value |> modBy 19) - 9.0) / 9.0) 2.0 * maximumValue)
+
+
+buildDict : Dimensions -> Float -> String -> (Int -> Triplet Float)
+buildDict dimensions maximumValue blurhash =
+    let
+        cache : Dict Int (Triplet Float)
+        cache =
+            foldDimensions dimensions
+                (\row column dict ->
+                    case row * dimensions.columns + column of
+                        0 ->
+                            let
+                                bits =
+                                    decodeBase83 (String.slice 2 6 blurhash)
+
+                                value =
+                                    Triplet
+                                        (srgbToLinear (bits |> Bitwise.shiftRightBy 16 |> Bitwise.and 0xFF))
+                                        (srgbToLinear (bits |> Bitwise.shiftRightBy 8 |> Bitwise.and 255))
+                                        (srgbToLinear (bits |> Bitwise.and 255))
+                            in
+                            Dict.insert 0 value dict
+
+                        i ->
+                            let
+                                key =
+                                    String.slice (4 + i * 2) (4 + (i + 1) * 2) blurhash
+
+                                value =
+                                    decodeAC maximumValue (decodeBase83 key)
+                            in
+                            Dict.insert i value dict
+                )
+                Dict.empty
+    in
+    -- creating a new function with one argument here make sure that the
+    -- cache is only created once, then re-used for all subsequent calls.
+    -- this works because we partially apply all arguments needed above.
+    \index ->
+        case Dict.get index cache of
+            Just v ->
+                v
+
+            Nothing ->
+                Triplet 0 0 0
+
+
+
+-- Phase 3: determine the color at a position
+
+
+calcPixel : Int -> Int -> Int -> Int -> Dimensions -> (Int -> Triplet Float) -> Color
+calcPixel x y width height filter lookup =
+    let
+        folder row column (Triplet pixel0 pixel1 pixel2) =
+            let
+                basis : Float
+                basis =
+                    cos (pi * toFloat x * toFloat column / toFloat width)
+                        * cos (pi * toFloat y * toFloat row / toFloat height)
+
+                (Triplet colour0 colour1 colour2) =
+                    lookup (row * filter.columns + column)
+            in
+            Triplet
+                (pixel0 + colour0 * basis)
+                (pixel1 + colour1 * basis)
+                (pixel2 + colour2 * basis)
+
+        (Triplet r g b) =
+            foldDimensions filter folder (Triplet 0 0 0)
+    in
+    Color.rgb255 (linearToSrgb r) (linearToSrgb g) (linearToSrgb b)
+
+
+
+-- Color conversion
+
+
+{-| srgb 0-255 integer to linear 0.0-1.0 floating point conversion.
+-}
+srgbToLinear : Int -> Float
+srgbToLinear srgbInt =
+    let
+        a =
+            toFloat srgbInt / 255
+    in
+    if a <= 0.04045 then
+        a / 12.92
+
+    else
+        ((a + 0.055) / 1.055) ^ 2.4
+
+
+unlinear : Color -> Color
+unlinear color =
+    let
+        { red, green, blue } =
+            Color.toRgba color
+    in
+    Color.rgb
+        (if red <= 0.04045 then
+            red / 12.92
+
+         else
+            ((red + 0.055) / 1.055) ^ 2.4
+        )
+        (if green <= 0.04045 then
+            green / 12.92
+
+         else
+            ((green + 0.055) / 1.055) ^ 2.4
+        )
+        (if blue <= 0.04045 then
+            blue / 12.92
+
+         else
+            ((blue + 0.055) / 1.055) ^ 2.4
+        )
+
+
+{-| linear 0.0-1.0 floating point to srgb 0-255 integer conversion.
+-}
+linearToSrgb : Float -> Int
+linearToSrgb linearFloat =
+    let
+        a =
+            clamp 0 1 linearFloat
+    in
+    if a <= 0.0031308 then
+        floor (a * 12.92 * 255 + 0.5)
+
+    else
+        floor ((1.055 * (a ^ (1 / 2.4)) - 0.055) * 255 + 0.5)
+
+
+
+-- Efficient folding over all positions in a grid
+
+
+decode : Int -> Int -> Float -> String -> List Color
+decode width height punch blurhash =
+    foldGrid width height punch blurhash folderList1d []
+
+
+{-| Fold from the top-left to the bottom-right. Useful for building up arrays
+-}
+foldDimensions : Dimensions -> (Int -> Int -> a -> a) -> a -> a
+foldDimensions { rows, columns } folder default =
+    let
+        go row column accum =
+            if column < columns - 1 then
+                go row (column + 1) (folder row column accum)
+
+            else if row < rows - 1 then
+                go (row + 1) 0 (folder row column accum)
+
+            else
+                folder row column accum
+    in
+    go 0 0 default
+
+
+{-| Fold from the bottom-right to the top-left Useful for building up lists
+-}
+foldDimensionsReversed : Dimensions -> (Int -> Int -> a -> a) -> a -> a
+foldDimensionsReversed { rows, columns } folder default =
+    let
+        go row column accum =
+            if column > 0 then
+                go row (column - 1) (folder row column accum)
+
+            else if row > 0 then
+                go (row - 1) (columns - 1) (folder row column accum)
+
+            else
+                folder row column accum
+    in
+    go (rows - 1) (columns - 1) default
+
+
+{-| Build up a flat list
+-}
+folderList1d : (Int -> Int -> a) -> Int -> Int -> List a -> List a
+folderList1d toValue row column accum =
+    toValue row column :: accum
+
+
+{-| Build up a 2D list
+-}
+folderList2d : (Int -> Int -> a) -> Int -> Int -> { row : List a, rows : List (List a) } -> { row : List a, rows : List (List a) }
+folderList2d toValue row column r =
+    let
+        value =
+            toValue row column
+    in
+    case column of
+        0 ->
+            { row = [], rows = (value :: r.row) :: r.rows }
+
+        _ ->
+            { row = value :: r.row, rows = r.rows }
+
+
+{-| encode an integer in base 83, the second parameter is the width: the number will be padded with 0's on the left untill that length is reached.
+-}
+encodeBase83 : Int -> Int -> String
+encodeBase83 value length =
+    let
+        go i accum =
+            if i <= length then
+                let
+                    digit =
+                        (value // (83 ^ (length - i))) |> modBy 83
+                in
+                go (i + 1) (accum ++ String.slice digit (digit + 1) alphabet)
+
+            else
+                accum
+    in
+    go 1 ""
+
+
+{-| Encode an image
+-}
+encode : { width : Int, height : Int } -> Image.Image -> String
+encode maskSize image =
+    case Image.toList2d image of
+        first :: rest ->
+            let
+                dimensions =
+                    { rows = 1 + List.length rest, columns = List.length first }
+            in
+            CellGrid.CellGrid dimensions (Image.Color.toArray image)
+                |> encodeHelp maskSize False
+
+        _ ->
+            ""
+
+
+encodeHelp : { width : Int, height : Int } -> Bool -> CellGrid Color -> String
+encodeHelp maskSize_ isLinear image =
+    let
+        componentsSize =
+            { rows = maskSize_.height
+            , columns = maskSize_.width
+            }
+
+        { components, max_ac_component } =
+            if isLinear then
+                findComponents componentsSize image
+
+            else
+                findComponents componentsSize (CellGrid.map unlinear <| image)
+    in
+    case components of
+        [] ->
+            ""
+
+        first :: rest ->
+            let
+                dc_value : Int
+                dc_value =
+                    let
+                        r =
+                            linearToSrgb first.r
+                                |> Bitwise.shiftLeftBy 16
+
+                        g =
+                            linearToSrgb first.g
+                                |> Bitwise.shiftLeftBy 8
+
+                        b =
+                            linearToSrgb first.b
+                    in
+                    r + g + b
+
+                quant_max_ac_component : Int
+                quant_max_ac_component =
+                    max 0 (min 82 (floor (max_ac_component * 166 - 0.5)))
+
+                ac_component_norm_factor : Float
+                ac_component_norm_factor =
+                    toFloat (quant_max_ac_component + 1) / 166.0
+
+                ac_values : List Int
+                ac_values =
+                    List.map
+                        (\{ r, g, b } ->
+                            let
+                                x =
+                                    max 0 (min 18 (floor (signPow (r / ac_component_norm_factor) 0.5 * 9.0 + 9.5))) * 19 * 19
+
+                                y =
+                                    max 0 (min 18 (floor (signPow (g / ac_component_norm_factor) 0.5 * 9.0 + 9.5))) * 19
+
+                                z =
+                                    max 0 (min 18 (floor (signPow (b / ac_component_norm_factor) 0.5 * 9.0 + 9.5)))
+                            in
+                            x + y + z
+                        )
+                        rest
+            in
+            encodeBase83 (componentsSize.columns - 1 + (componentsSize.rows - 1) * 9) 1
+                ++ encodeBase83 quant_max_ac_component 1
+                ++ encodeBase83 dc_value 4
+                ++ List.foldl (\new accum -> accum ++ encodeBase83 new 2) "" ac_values
+
+
+findComponents : Dimensions -> CellGrid Color -> { components : List { r : Float, g : Float, b : Float }, max_ac_component : Float }
+findComponents dimensions ((CellGrid.CellGrid grid _) as cellgrid) =
+    foldDimensionsReversed dimensions
+        (\row column { components, max_ac_component } ->
+            let
+                { r, g, b } =
+                    encodePixel (Position row column) cellgrid
+
+                size =
+                    toFloat (grid.rows * grid.columns)
+
+                normalized =
+                    { r = r / size, g = g / size, b = b / size }
+            in
+            { components = normalized :: components
+            , max_ac_component =
+                if not (row == 0 && column == 0) then
+                    max max_ac_component
+                        (max (abs normalized.r) (max (abs normalized.g) (abs normalized.b)))
+
+                else
+                    max_ac_component
+            }
+        )
+        { components = [], max_ac_component = 0 }
+
+
+encodePixel : Position -> CellGrid Color -> { r : Float, g : Float, b : Float }
+encodePixel position ((CellGrid.CellGrid dimensions _) as cellgrid) =
+    let
+        norm_factor =
+            if i == 0 && j == 0 then
+                1.0
+
+            else
+                2.0
+
+        i =
+            position.column
+
+        j =
+            position.row
+    in
+    CellGrid.foldl
+        (\value { r, g, b, index } ->
+            let
+                pos =
+                    CellGrid.matrixIndex dimensions index
+
+                x =
+                    pos.column
+
+                y =
+                    pos.row
+
+                basis =
+                    norm_factor * cos (pi * toFloat i * toFloat x / toFloat dimensions.columns) * cos (pi * toFloat j * toFloat y / toFloat dimensions.rows)
+
+                { red, green, blue } =
+                    Color.toRgba value
+
+                result =
+                    { r = r + basis * red
+                    , g = g + basis * green
+                    , b = b + basis * blue
+                    , index = index + 1
+                    }
+            in
+            result
+        )
+        { r = 0, g = 0, b = 0, index = 0 }
+        cellgrid
+        |> (\{ r, g, b } -> { r = r, g = g, b = b })

--- a/src/Internal.elm
+++ b/src/Internal.elm
@@ -1,7 +1,8 @@
-module Blurhash exposing
+module Internal exposing
     ( toUri
     , toCellGrid
-    , encode, encodeBase83
+    , encode, encodeCellGrid, encodeHelp
+    , encodeBase83, decodeBase83
     )
 
 {-| Display blur hashes in elm
@@ -26,7 +27,8 @@ module Blurhash exposing
 
 @docs toUri
 @docs toCellGrid
-@docs encode, encodeBase83
+@docs encode, encodeCellGrid, encodeHelp
+@docs encodeBase83, decodeBase83
 
 -}
 
@@ -422,6 +424,11 @@ encode maskSize image =
 
         _ ->
             ""
+
+
+encodeCellGrid : { width : Int, height : Int } -> CellGrid Color -> String
+encodeCellGrid mask grid =
+    encodeHelp mask False grid
 
 
 encodeHelp : { width : Int, height : Int } -> Bool -> CellGrid Color -> String

--- a/tests/TestBlurhash.elm
+++ b/tests/TestBlurhash.elm
@@ -1,44 +1,106 @@
 module TestBlurhash exposing (suite)
 
-import Blurhash
+import CellGrid
 import Color
 import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
+import Internal
 import Test exposing (..)
 
 
 suite : Test
 suite =
-    describe "Blurhash"
-        [ test "example (punch=0.5)" <|
-            \_ ->
-                Blurhash.toUri { width = 5, height = 5 } 0.5 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
-                    |> Expect.equal "data:image/bmp;base64,Qk3eAAAAAAAAAHoAAABsAAAABQAAAAUAAAABACAAAwAAAGQAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/VYjA/02Dv/9Cf8H/R4LF/02CwP9ThsL/Rn/B/z18x/9Ohc7/UYXF/1iJwf9Lgbz/Qny//1CFyf9Pg8P/VIi9/1CEuf9JgLb/SYG7/1CDvf9PhLz/UIW5/0uCtP9Ef7T/UoO6"
-        , test "example (punch=1.0)" <|
-            \_ ->
-                Blurhash.toUri { width = 5, height = 5 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
-                    |> Expect.equal "data:image/bmp;base64,Qk3eAAAAAAAAAHoAAABsAAAABQAAAAUAAAABACAAAwAAAGQAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/Xo7B/06Evv82e8P/QoHL/02Bwf9aicb/P3zD/yd2zv9QiNz/VofL/2KQw/9KgLr/NnW//1SI0/9Shcf/XI28/1SGs/9Ffa3/R4G4/1ODu/9Rhrn/VIez/0qDqP88fKj/WIW2"
-        , test "example { width = 4, height = 6 }" <|
-            \_ ->
-                Blurhash.toUri { width = 4, height = 6 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
-                    |> Expect.equal "data:image/bmp;base64,Qk3aAAAAAAAAAHoAAABsAAAABAAAAAYAAAABACAAAwAAAGAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/YJDA/0qCvP84fcT/SYHC/1mJxf83esT/O3/V/1aIz/9ejMX/N3e//0J/1P9ZitL/YpHB/0d9s/9Gf8L/VIfI/1mLu/9RhLD/Q36u/1CDuf9Rhrn/U4ex/z9+pv9PgbI="
-        , test "example { width = 2, height = 2 }" <|
-            \_ ->
-                Blurhash.toUri { width = 2, height = 2 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
-                    |> Expect.equal "data:image/bmp;base64,Qk2KAAAAAAAAAHoAAABsAAAAAgAAAAIAAAABACAAAwAAABAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/XY3A/z9+w/9djcD/P37D"
+    describe "Internal"
+        [ describe "decoding" <|
+            let
+                decodeTest dim punch input colors =
+                    test (Debug.toString dim ++ " @" ++ String.fromFloat punch ++ " " ++ input) <|
+                        \_ ->
+                            Internal.toCellGrid dim punch input
+                                |> CellGrid.toLists
+                                |> Expect.equal colors
+            in
+            [ decodeTest { width = 4, height = 4 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 173 135 83, Color.rgb255 166 126 63, Color.rgb255 173 129 79 ]
+                , [ Color.rgb255 185 143 95, Color.rgb255 176 129 77, Color.rgb255 185 126 69, Color.rgb255 192 132 81 ]
+                , [ Color.rgb255 198 140 94, Color.rgb255 193 119 55, Color.rgb255 214 127 66, Color.rgb255 211 138 89 ]
+                , [ Color.rgb255 192 140 91, Color.rgb255 194 126 64, Color.rgb255 207 126 57, Color.rgb255 201 133 80 ]
+                ]
+            , decodeTest { width = 5, height = 5 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 173 135 84, Color.rgb255 170 131 74, Color.rgb255 166 124 60, Color.rgb255 177 133 88 ]
+                , [ Color.rgb255 181 141 92, Color.rgb255 176 134 84, Color.rgb255 175 125 69, Color.rgb255 183 129 71, Color.rgb255 186 131 83 ]
+                , [ Color.rgb255 195 144 98, Color.rgb255 187 128 74, Color.rgb255 193 117 54, Color.rgb255 212 136 84, Color.rgb255 200 133 82 ]
+                , [ Color.rgb255 197 137 90, Color.rgb255 197 124 63, Color.rgb255 208 118 39, Color.rgb255 220 136 80, Color.rgb255 204 135 86 ]
+                , [ Color.rgb255 190 142 94, Color.rgb255 190 132 78, Color.rgb255 197 123 54, Color.rgb255 203 129 66, Color.rgb255 193 129 77 ]
+                ]
+            , decodeTest { width = 5, height = 4 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 173 135 84, Color.rgb255 170 131 74, Color.rgb255 166 124 60, Color.rgb255 177 133 88 ]
+                , [ Color.rgb255 185 143 95, Color.rgb255 178 133 82, Color.rgb255 178 123 67, Color.rgb255 191 131 75, Color.rgb255 189 131 82 ]
+                , [ Color.rgb255 198 140 94, Color.rgb255 193 124 67, Color.rgb255 203 117 44, Color.rgb255 220 138 84, Color.rgb255 204 135 85 ]
+                , [ Color.rgb255 192 140 91, Color.rgb255 193 130 72, Color.rgb255 202 122 49, Color.rgb255 208 131 70, Color.rgb255 196 132 81 ]
+                ]
+            , decodeTest { width = 4, height = 5 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 173 135 83, Color.rgb255 166 126 63, Color.rgb255 173 129 79 ]
+                , [ Color.rgb255 181 141 92, Color.rgb255 175 131 80, Color.rgb255 179 126 68, Color.rgb255 186 131 80 ]
+                , [ Color.rgb255 195 144 98, Color.rgb255 186 122 64, Color.rgb255 204 127 69, Color.rgb255 206 137 86 ]
+                , [ Color.rgb255 197 137 90, Color.rgb255 198 119 51, Color.rgb255 216 127 61, Color.rgb255 210 138 89 ]
+                , [ Color.rgb255 190 142 94, Color.rgb255 191 129 70, Color.rgb255 201 125 56, Color.rgb255 197 131 76 ]
+                ]
+            , decodeTest { width = 5, height = 5 } 1 "UBMOZfK1GG%LBBNG,;Rj2skq=eE1s9n4S5Na" <|
+                [ [ Color.rgb255 170 134 82, Color.rgb255 175 134 84, Color.rgb255 173 129 73, Color.rgb255 167 124 57, Color.rgb255 180 134 85 ]
+                , [ Color.rgb255 181 141 92, Color.rgb255 179 134 84, Color.rgb255 179 125 70, Color.rgb255 186 129 71, Color.rgb255 190 133 83 ]
+                , [ Color.rgb255 196 143 96, Color.rgb255 191 128 73, Color.rgb255 198 119 54, Color.rgb255 214 137 86, Color.rgb255 204 134 85 ]
+                , [ Color.rgb255 197 137 86, Color.rgb255 198 123 58, Color.rgb255 211 118 34, Color.rgb255 221 138 80, Color.rgb255 206 137 88 ]
+                , [ Color.rgb255 190 142 94, Color.rgb255 192 133 77, Color.rgb255 200 124 53, Color.rgb255 205 132 65, Color.rgb255 196 132 77 ]
+                ]
+            , decodeTest { width = 5, height = 5 } 0.5 "UBMOZfK1GG%LBBNG,;Rj2skq=eE1s9n4S5Na" <|
+                [ [ Color.rgb255 183 133 79, Color.rgb255 185 132 80, Color.rgb255 184 130 75, Color.rgb255 181 128 67, Color.rgb255 187 132 81 ]
+                , [ Color.rgb255 188 136 85, Color.rgb255 187 132 80, Color.rgb255 187 128 73, Color.rgb255 190 130 74, Color.rgb255 192 132 80 ]
+                , [ Color.rgb255 195 137 87, Color.rgb255 192 130 74, Color.rgb255 196 125 66, Color.rgb255 205 134 81, Color.rgb255 199 133 81 ]
+                , [ Color.rgb255 195 134 81, Color.rgb255 196 127 68, Color.rgb255 203 125 59, Color.rgb255 208 135 78, Color.rgb255 200 134 82 ]
+                , [ Color.rgb255 192 137 85, Color.rgb255 193 132 77, Color.rgb255 197 128 66, Color.rgb255 199 131 71, Color.rgb255 195 131 76 ]
+                ]
+            , decodeTest { width = 4, height = 3 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 173 135 83, Color.rgb255 166 126 63, Color.rgb255 173 129 79 ]
+                , [ Color.rgb255 191 145 98, Color.rgb255 181 125 71, Color.rgb255 196 127 70, Color.rgb255 201 135 84 ]
+                , [ Color.rgb255 195 137 89, Color.rgb255 198 122 55, Color.rgb255 214 127 59, Color.rgb255 207 136 86 ]
+                ]
+            , decodeTest { width = 3, height = 4 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 172 133 80, Color.rgb255 168 125 65 ]
+                , [ Color.rgb255 185 143 95, Color.rgb255 176 124 70, Color.rgb255 193 133 79 ]
+                , [ Color.rgb255 198 140 94, Color.rgb255 197 114 40, Color.rgb255 218 140 90 ]
+                , [ Color.rgb255 192 140 91, Color.rgb255 198 122 52, Color.rgb255 207 133 76 ]
+                ]
+            , decodeTest { width = 3, height = 3 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" <|
+                [ [ Color.rgb255 172 134 81, Color.rgb255 172 133 80, Color.rgb255 168 125 65 ]
+                , [ Color.rgb255 191 145 98, Color.rgb255 181 119 61, Color.rgb255 205 137 84 ]
+                , [ Color.rgb255 195 137 89, Color.rgb255 202 118 41, Color.rgb255 214 137 83 ]
+                ]
+            ]
+        , describe "encoding" <|
+            let
+                encodeTest dim punch input size output =
+                    test (Debug.toString dim ++ " @" ++ String.fromFloat punch ++ " " ++ input) <|
+                        \_ ->
+                            Internal.toCellGrid dim punch input
+                                |> Internal.encodeHelp size False
+                                |> Expect.equal output
+            in
+            [ encodeTest { width = 30, height = 30 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH" { width = 4, height = 4 } "UBL_:rx@GG^jP9R*w_WB2skV$jM{=wnOWYR+"
+            , encodeTest { width = 30, height = 30 } 1 "UBMOZfK1GG%LBBNG,;Rj2skq=eE1s9n4S5Na" { width = 4, height = 4 } "UCMOZftPGG^jO?R*w_WB2sbv$jNG-SjEWYS2"
+            , encodeTest { width = 30, height = 30 } 0.5 "UBMOZfK1GG%LBBNG,;Rj2skq=eE1s9n4S5Na" { width = 4, height = 4 } "U7MOZf-nKi~Ax[WUw_ae70bbxGNG^NniWqWV"
+            , encodeTest { width = 20, height = 30 } 0.75 "UBMOZfK1GG%LBBNG,;Rj2skq=eE1s9n4S5Na" { width = 4, height = 5 } "dAMOZf?EKj~Ab^WUw_WB70bvxGNG=vniWXWVWpayjtay"
+            ]
+        , describe "base83 encoding" <|
+            let
+                base83Test value length expected =
+                    test (String.fromInt value ++ " -> " ++ expected) <|
+                        \_ ->
+                            Internal.encodeBase83 value length
+                                |> Expect.equal expected
+            in
+            [ base83Test 0 2 "00"
+            , base83Test 20 2 "0K"
+            , base83Test 83 4 "0010"
+            ]
         ]
-
-
-toRgb255 color =
-    let
-        { red, green, blue } =
-            Color.toRgba color
-    in
-    ( round (red * 255)
-    , round (green * 255)
-    , round (blue * 255)
-    )
-
-
-toColor ( a, b, c ) =
-    Color.rgb255 a b c

--- a/tests/TestBlurhash.elm
+++ b/tests/TestBlurhash.elm
@@ -1,0 +1,44 @@
+module TestBlurhash exposing (suite)
+
+import Blurhash
+import Color
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Test exposing (..)
+
+
+suite : Test
+suite =
+    describe "Blurhash"
+        [ test "example (punch=0.5)" <|
+            \_ ->
+                Blurhash.toUri { width = 5, height = 5 } 0.5 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+                    |> Expect.equal "data:image/bmp;base64,Qk3eAAAAAAAAAHoAAABsAAAABQAAAAUAAAABACAAAwAAAGQAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/VYjA/02Dv/9Cf8H/R4LF/02CwP9ThsL/Rn/B/z18x/9Ohc7/UYXF/1iJwf9Lgbz/Qny//1CFyf9Pg8P/VIi9/1CEuf9JgLb/SYG7/1CDvf9PhLz/UIW5/0uCtP9Ef7T/UoO6"
+        , test "example (punch=1.0)" <|
+            \_ ->
+                Blurhash.toUri { width = 5, height = 5 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+                    |> Expect.equal "data:image/bmp;base64,Qk3eAAAAAAAAAHoAAABsAAAABQAAAAUAAAABACAAAwAAAGQAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/Xo7B/06Evv82e8P/QoHL/02Bwf9aicb/P3zD/yd2zv9QiNz/VofL/2KQw/9KgLr/NnW//1SI0/9Shcf/XI28/1SGs/9Ffa3/R4G4/1ODu/9Rhrn/VIez/0qDqP88fKj/WIW2"
+        , test "example { width = 4, height = 6 }" <|
+            \_ ->
+                Blurhash.toUri { width = 4, height = 6 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+                    |> Expect.equal "data:image/bmp;base64,Qk3aAAAAAAAAAHoAAABsAAAABAAAAAYAAAABACAAAwAAAGAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/YJDA/0qCvP84fcT/SYHC/1mJxf83esT/O3/V/1aIz/9ejMX/N3e//0J/1P9ZitL/YpHB/0d9s/9Gf8L/VIfI/1mLu/9RhLD/Q36u/1CDuf9Rhrn/U4ex/z9+pv9PgbI="
+        , test "example { width = 2, height = 2 }" <|
+            \_ ->
+                Blurhash.toUri { width = 2, height = 2 } 1 "UBL_:rOpGG-oBUNG,qRj2so|=eE1w^n4S5NH"
+                    |> Expect.equal "data:image/bmp;base64,Qk2KAAAAAAAAAHoAAABsAAAAAgAAAAIAAAABACAAAwAAABAAAAATCwAAEwsAAAAAAAAAAAAAAAAA/wAA/wAA/wAA/wAAAFdpbiAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD/XY3A/z9+w/9djcD/P37D"
+        ]
+
+
+toRgb255 color =
+    let
+        { red, green, blue } =
+            Color.toRgba color
+    in
+    ( round (red * 255)
+    , round (green * 255)
+    , round (blue * 255)
+    )
+
+
+toColor ( a, b, c ) =
+    Color.rgb255 a b c

--- a/tests/elm-verify-examples.json
+++ b/tests/elm-verify-examples.json
@@ -1,0 +1,4 @@
+{
+  "root": "../src",
+  "tests": ["Blurhash", "README.md"]
+}


### PR DESCRIPTION
Hey, this is a cool project! Use from this PR what you want, or merge it all if you think it looks good. Always happy to elaborate on some of the choices/changes I made. 

I had some fun optimizing this after recent work on `justgook/elm-image` and `jxxcarlson/elm-cell-grid`. I got the image generation time down to 30ms on my machine (I think it was around 100ms). 

The big gain is switching to bmp instead of png: png is compressed and that is a slow process. Bmp is much faster and I could barely notice the difference in the resulting image. bmp uses a 2d list internally, so it is most efficient to build up a 2d list ourselves rather than elm-image having to convert it for us from a flat list to 2d. 

to generate that 2d list efficiently, we must work from the bottom-right up to the top-left because lists grow to the left. I implemented some neat functions that fold over all values in a `{ rows : Int, columns : Int }` range without first building a list of indices.

the recent elm-image release gives helpers for working with colors, so the integer -> color logic is no longer needed. 

